### PR TITLE
Add Adjustable Bumper support for boosting holdables

### DIFF
--- a/Loenn/entities/adjustableBumper.lua
+++ b/Loenn/entities/adjustableBumper.lua
@@ -13,7 +13,9 @@ return {
 				cardinal = false,
 				snapUp = false,
 				snapDown = false,
-				wobble = true
+				wobble = true,
+				boostHoldables = false,
+				ignoreHoldableWhenHot = false
 			}
 		},
 		{
@@ -28,7 +30,9 @@ return {
 				cardinal = false,
 				snapUp = false,
 				snapDown = false,
-				wobble = true
+				wobble = true,
+				boostHoldables = false,
+				ignoreHoldableWhenHot = false
 			}
 		},
 		{
@@ -43,7 +47,9 @@ return {
 				cardinal = false,
 				snapUp = false,
 				snapDown = false,
-				wobble = true
+				wobble = true,
+				boostHoldables = false,
+				ignoreHoldableWhenHot = false
 			}
 		},
 		{
@@ -58,7 +64,9 @@ return {
 				cardinal = false,
 				snapUp = false,
 				snapDown = false,
-				wobble = true
+				wobble = true,
+				boostHoldables = false,
+				ignoreHoldableWhenHot = false
 			}
 		}
 	},
@@ -74,7 +82,8 @@ return {
 		"cardinal",
 		"snapUp",
 		"snapDown",
-		"wobble"
+		"wobble",
+		"boostHoldables"
 	},
 	fieldInformation = {
 		bumperBoost = {

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -11,6 +11,8 @@ entities.progHelper/adjustableBumper.attributes.description.fireMode=When to swi
 entities.progHelper/adjustableBumper.attributes.description.cardinal=Restrict bumper launch angles to the 4 cardinal directions, with equal hit angle windows
 entities.progHelper/adjustableBumper.attributes.description.snapUp=Adds a range of hit angles to the top of the bumper that will launch the player straight up
 entities.progHelper/adjustableBumper.attributes.description.snapDown=Adds a range of hit angles to the bottom of the bumper that will launch the player straight down
+entities.progHelper/adjustableBumper.attributes.description.boostHoldables=Allows the bumper to boost carriable entities.
+entities.progHelper/adjustableBumper.attributes.description.ignoreHoldableWhenHot=Ignores boosting carriable entities when the core mode is set to hot.\nDoes nothing if "Boost Holdables" isn't set.
 
 entities.progHelper/adjustableFallingBlock.placements.name.default=Adjustable Falling Block
 entities.progHelper/adjustableFallingBlock.placements.description.default=Falling Block with a customizable delay and player wait time

--- a/src/Entities/AdjustableBumper.cs
+++ b/src/Entities/AdjustableBumper.cs
@@ -26,6 +26,7 @@ public class AdjustableBumper : Entity {
     private bool fireMode;
     private bool goBack;
     private Vector2 hitDir;
+    private bool ignoreHoldableWhenHot;
 
     public AdjustableBumper(EntityData data, Vector2 offset) : base(data.Position + offset) {
         respawnTime = data.Float("respawnTime");
@@ -35,6 +36,13 @@ public class AdjustableBumper : Entity {
         bumperBoost = data.Enum<BumperBoostType>("bumperBoost");
         dashRestores = data.Enum<DashRestores>("dashRestores");
         fireModeType = data.Enum<BumperFireModeType>("fireMode");
+        if(data.Bool("boostHoldables", false))
+        {
+            Add(new HoldableCollider(OnHoldable));
+        }
+
+        ignoreHoldableWhenHot = data.Bool("ignoreHoldableWhenHot", false);
+
         anchor = Position;
 
         var node = data.FirstNodeNullable();
@@ -156,6 +164,34 @@ public class AdjustableBumper : Entity {
         sprite.Visible = false;
         spriteEvil.Visible = true;
     }
+   
+    private void OnHoldable(Holdable hold)
+    {
+        if (respawnTimer > 0f || (fireMode && ignoreHoldableWhenHot)) return;
+
+        respawnTimer = respawnTime;
+
+        var direction = HoldableLaunch(hold);
+
+        sprite.Play("hit", true);
+        spriteEvil.Play("hit", true);
+        light.Visible = false;
+        bloom.Visible = false;
+
+        var level = SceneAs<Level>();
+
+        level.DirectionalShake(direction, 0.15f);
+        level.Displacement.AddBurst(Center, 0.3f, 8f, 32f, 0.8f);
+        level.Particles.Emit(Bumper.P_Launch, 12, Center + 1f * direction, 3f * Vector2.One, direction.Angle());
+        Audio.Play(SFX.game_06_pinballbumper_hit, Position);
+
+        if (fireModeType != BumperFireModeType.AfterHit) return;
+
+        fireMode = true;
+        sprite.Visible = false;
+        spriteEvil.Visible = true;
+    }
+
 
     private void OnCoreModeChange(Session.CoreModes coreMode) {
         if (fireModeType != BumperFireModeType.CoreMode)
@@ -215,6 +251,37 @@ public class AdjustableBumper : Entity {
         dynamicData.Set("dashCooldownTimer", 0.2f);
         player.StateMachine.State = 7;
         SlashFx.Burst(player.Center, player.Speed.Angle());
+
+        return direction;
+    }
+
+    private Vector2 HoldableLaunch(Holdable hold)
+    {
+        Input.Rumble(RumbleStrength.Strong, RumbleLength.Medium);
+        Celeste.Freeze(0.1f);
+
+        var direction = (hold.Entity.Center - Center).SafeNormalize(-Vector2.UnitY);
+        float dot = direction.Y;
+
+        if (cardinal)
+            direction = direction.FourWayNormal();
+        else if (snapUp && dot <= -0.8f)
+            direction = -Vector2.UnitY;
+        else if (snapDown && dot >= 0.8f)
+            direction = Vector2.UnitY;
+        else if (dot >= -0.55 || dot <= 0.65)
+            direction = Math.Sign(direction.X) * Vector2.UnitX;
+
+        var speed = 280f * direction;
+
+        if (speed.Y <= 50f)
+        {
+            speed.Y = Math.Min(speed.Y, -150f);
+        }
+
+        hold.SetSpeed(speed);
+
+        SlashFx.Burst(hold.Entity.Center, hold.GetSpeed().Angle());
 
         return direction;
     }

--- a/src/Entities/AdjustableBumper.cs
+++ b/src/Entities/AdjustableBumper.cs
@@ -167,7 +167,7 @@ public class AdjustableBumper : Entity {
    
     private void OnHoldable(Holdable hold)
     {
-        if (respawnTimer > 0f || (fireMode && ignoreHoldableWhenHot)) return;
+        if (respawnTimer > 0f || (fireMode && ignoreHoldableWhenHot) || hold.IsHeld) return;
 
         respawnTimer = respawnTime;
 


### PR DESCRIPTION
Allow Adjustable Bumpers to boost carriable entities, if an option is set.
Implements `boostHoldables` and `ignoreHoldableWhenHot`.