### PR TITLE
AdjustableBumper node position fix

### DIFF
--- a/Loenn/entities/adjustableBumper.lua
+++ b/Loenn/entities/adjustableBumper.lua
@@ -121,5 +121,6 @@ return {
 		}
 	},
 	nodeLimits = { 0, 1 },
+	nodeLineRenderType = "line",
 	texture = "objects/Bumper/Idle22"
 }

--- a/src/Entities/AdjustableBumper.cs
+++ b/src/Entities/AdjustableBumper.cs
@@ -46,7 +46,7 @@ public class AdjustableBumper : Entity {
 
         anchor = Position;
 
-        var node = data.FirstNodeNullable();
+        var node = data.FirstNodeNullable(offset);
 
         if (node.HasValue) {
             var start = Position;


### PR DESCRIPTION
Hi! your AdjustableBumper wasn't taking into account the bumper's offset when generating its node, so it spawned at {0,0} world position every time, leading to a noded bumper flying off screen at top speed. This PR fixes that to make the node appear relative to the parent bumper. I also added a line to the lua plugin to render a line between nodes. It just makes things a little easier to track when you have multiple bumpers in the same area.

Tested this and it fixes the issue!